### PR TITLE
Fix redirected listener log message

### DIFF
--- a/Assets/ReflectionOfAmber/Scripts/Input/InputService.cs
+++ b/Assets/ReflectionOfAmber/Scripts/Input/InputService.cs
@@ -36,7 +36,7 @@ namespace ReflectionOfAmber.Scripts.Input
         {
             if (m_forceRedirected.Peek() != inputListener)
             {
-                Debug.LogError($"Wrong redirected listener: {inputListener.GetType()}, current is {m_forceRedirected.GetType()}");
+                Debug.LogError($"Wrong redirected listener: {inputListener.GetType()}, current is {m_forceRedirected.Peek().GetType()}");
                 return;
             }
 


### PR DESCRIPTION
## Summary
- show redirected listener type when mismatch occurs

## Testing
- `mcs Assets/ReflectionOfAmber/Scripts/Input/InputService.cs` *(fails: command not found)*
- `csc Assets/ReflectionOfAmber/Scripts/Input/InputService.cs` *(fails: command not found)*
- `msbuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4e4cf0a88331b3d1d9f9eb4aa08b