### PR TITLE
Add edit mode tests for InputService

### DIFF
--- a/Assets/Tests/EditMode/EditModeTests.asmdef
+++ b/Assets/Tests/EditMode/EditModeTests.asmdef
@@ -1,0 +1,11 @@
+{
+    "name": "Tests.EditMode",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": ["Editor"]
+}

--- a/Assets/Tests/EditMode/EditModeTests.asmdef.meta
+++ b/Assets/Tests/EditMode/EditModeTests.asmdef.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 40b2c43a-5b78-4548-b447-d8382b375876
+timeCreated: 1739811300

--- a/Assets/Tests/EditMode/InputServiceTests.cs
+++ b/Assets/Tests/EditMode/InputServiceTests.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using ReflectionOfAmber.Scripts.Input;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests.EditMode
+{
+    public class InputServiceTests
+    {
+        private MethodInfo _setAction;
+
+        [SetUp]
+        public void Setup()
+        {
+            _setAction = typeof(InputService).GetMethod("SetAction", BindingFlags.Instance | BindingFlags.NonPublic);
+        }
+
+        private void InvokeSetAction(InputService service, InputAction action)
+        {
+            _setAction.Invoke(service, new object[] { action });
+        }
+
+        private class MockListener : IInputListener
+        {
+            public InputAction LastAction = InputAction.NONE;
+            public void OnInputAction(InputAction inputAction)
+            {
+                LastAction = inputAction;
+            }
+        }
+
+        [Test]
+        public void ForceRedirectInputAndRemoveForceRedirected_WorksAndLogsError()
+        {
+            var service = new InputService();
+            var listener = new MockListener();
+            var wrongListener = new MockListener();
+
+            service.AddListener(listener);
+            service.ForceRedirectInput(listener);
+
+            InvokeSetAction(service, InputAction.SPACE);
+            Assert.AreEqual(InputAction.SPACE, listener.LastAction);
+
+            LogAssert.Expect(LogType.Error, new Regex("Wrong redirected listener"));
+            service.RemoveForceRedirected(wrongListener);
+
+            InvokeSetAction(service, InputAction.PAUSE);
+            Assert.AreEqual(InputAction.PAUSE, listener.LastAction);
+
+            service.RemoveForceRedirected(listener);
+
+            InvokeSetAction(service, InputAction.SPACE);
+            Assert.AreEqual(InputAction.SPACE, listener.LastAction);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/InputServiceTests.cs.meta
+++ b/Assets/Tests/EditMode/InputServiceTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 533129a6-70a4-4dfe-be10-727100f0add6
+timeCreated: 1739811300


### PR DESCRIPTION
## Summary
- add EditMode test assembly definition referencing Unity TestFramework
- test InputService redirection and error handling

## Testing
- `unity-editor -runTests -projectPath . -testPlatform editmode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4e80c1e083318150cc4509239fbe